### PR TITLE
Prepared to receive packets via serial and write them to the internal SD card

### DIFF
--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
@@ -58,8 +58,6 @@ void wifi_marauder_console_output_handle_rx_packets_cb(uint8_t* buf, size_t len,
     if (app->is_writing) {
         storage_file_write(app->capture_file, buf, len);
     }
-
-    view_dispatcher_send_custom_event(app->view_dispatcher, WifiMarauderEventRefreshConsoleOutput);
 }
 
 void wifi_marauder_scene_console_output_on_enter(void* context) {

--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
@@ -1,31 +1,5 @@
 #include "../wifi_marauder_app_i.h"
 
-void wifi_marauder_get_prefix_from_cmd(char* dest, const char* command) {
-    int start, end, delta;
-    start = strlen("sniff");
-    end = strcspn(command, " ");
-    delta = end - start;
-    strncpy(dest, command + start, end - start);
-    dest[delta] = '\0';    
-}
-
-void wifi_marauder_create_pcap_file(WifiMarauderApp* app) {
-    char prefix[10];
-    char capture_file_path[100];
-    wifi_marauder_get_prefix_from_cmd(prefix, app->selected_tx_string);
-
-    app->capture_file = storage_file_alloc(app->storage);
-    int i=0;
-    do{
-        snprintf(capture_file_path, sizeof(capture_file_path), "%s/%s_%d.pcap", MARAUDER_APP_FOLDER, prefix, i);
-        i++;
-    } while(storage_file_exists(app->storage, capture_file_path));
-
-    if (!storage_file_open(app->capture_file, capture_file_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
-        dialog_message_show_storage_error(app->dialogs, "Cannot open pcap file");
-    }
-}
-
 void wifi_marauder_console_output_handle_rx_data_cb(uint8_t* buf, size_t len, void* context) {
     furi_assert(context);
     WifiMarauderApp* app = context;

--- a/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
+++ b/applications/plugins/wifi_marauder_companion/scenes/wifi_marauder_scene_console_output.c
@@ -112,7 +112,6 @@ void wifi_marauder_scene_console_output_on_exit(void* context) {
     app->is_writing = false;
     if (app->capture_file && storage_file_is_open(app->capture_file)) {
         storage_file_close(app->capture_file);
-        storage_file_free(app->capture_file);
     }
 
 }

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
@@ -93,6 +93,7 @@ void wifi_marauder_app_free(WifiMarauderApp* app) {
     scene_manager_free(app->scene_manager);
 
     wifi_marauder_uart_free(app->uart);
+    wifi_marauder_uart_free(app->lp_uart);
 
     // Close records
     furi_record_close(RECORD_GUI);
@@ -108,7 +109,8 @@ int32_t wifi_marauder_app(void* p) {
 
     wifi_marauder_make_app_folder(wifi_marauder_app);
 
-    wifi_marauder_app->uart = wifi_marauder_uart_init(wifi_marauder_app);
+    wifi_marauder_app->uart = wifi_marauder_usart_init(wifi_marauder_app);
+    wifi_marauder_app->lp_uart = wifi_marauder_lp_uart_init(wifi_marauder_app);
 
     view_dispatcher_run(wifi_marauder_app->view_dispatcher);
 

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
@@ -27,6 +27,7 @@ WifiMarauderApp* wifi_marauder_app_alloc() {
     app->gui = furi_record_open(RECORD_GUI);
     app->dialogs = furi_record_open(RECORD_DIALOGS);
     app->storage = furi_record_open(RECORD_STORAGE);
+    app->capture_file = storage_file_alloc(app->storage);
 
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&wifi_marauder_scene_handlers, app);
@@ -87,6 +88,7 @@ void wifi_marauder_app_free(WifiMarauderApp* app) {
     text_box_free(app->text_box);
     furi_string_free(app->text_box_store);
     text_input_free(app->text_input);
+    storage_file_free(app->capture_file);
 
     // View dispatcher
     view_dispatcher_free(app->view_dispatcher);

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
@@ -25,8 +25,8 @@ WifiMarauderApp* wifi_marauder_app_alloc() {
     WifiMarauderApp* app = malloc(sizeof(WifiMarauderApp));
 
     app->gui = furi_record_open(RECORD_GUI);
-    app->storage = furi_record_open(RECORD_STORAGE);
     app->dialogs = furi_record_open(RECORD_DIALOGS);
+    app->storage = furi_record_open(RECORD_STORAGE);
 
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&wifi_marauder_scene_handlers, app);

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app.c
@@ -25,6 +25,8 @@ WifiMarauderApp* wifi_marauder_app_alloc() {
     WifiMarauderApp* app = malloc(sizeof(WifiMarauderApp));
 
     app->gui = furi_record_open(RECORD_GUI);
+    app->storage = furi_record_open(RECORD_STORAGE);
+    app->dialogs = furi_record_open(RECORD_DIALOGS);
 
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&wifi_marauder_scene_handlers, app);
@@ -67,6 +69,14 @@ WifiMarauderApp* wifi_marauder_app_alloc() {
     return app;
 }
 
+void wifi_marauder_make_app_folder(WifiMarauderApp* app) {
+    furi_assert(app);
+
+    if (!storage_simply_mkdir(app->storage, MARAUDER_APP_FOLDER)) {
+        dialog_message_show_storage_error(app->dialogs, "Cannot create\napp folder");
+    }
+}
+
 void wifi_marauder_app_free(WifiMarauderApp* app) {
     furi_assert(app);
 
@@ -86,6 +96,8 @@ void wifi_marauder_app_free(WifiMarauderApp* app) {
 
     // Close records
     furi_record_close(RECORD_GUI);
+    furi_record_close(RECORD_STORAGE);
+    furi_record_close(RECORD_DIALOGS);
 
     free(app);
 }
@@ -93,6 +105,8 @@ void wifi_marauder_app_free(WifiMarauderApp* app) {
 int32_t wifi_marauder_app(void* p) {
     UNUSED(p);
     WifiMarauderApp* wifi_marauder_app = wifi_marauder_app_alloc();
+
+    wifi_marauder_make_app_folder(wifi_marauder_app);
 
     wifi_marauder_app->uart = wifi_marauder_uart_init(wifi_marauder_app);
 

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -41,6 +41,7 @@ struct WifiMarauderApp {
     VariableItemList* var_item_list;
 
     WifiMarauderUart* uart;
+    WifiMarauderUart* lp_uart;
     int selected_menu_index;
     int selected_option_index[NUM_MENU_ITEMS];
     const char* selected_tx_string;

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -14,10 +14,15 @@
 #include <gui/modules/text_input.h>
 #include <gui/modules/variable_item_list.h>
 
+#include <storage/storage.h>
+#include <dialogs/dialogs.h>
+
 #define NUM_MENU_ITEMS (16)
 
 #define WIFI_MARAUDER_TEXT_BOX_STORE_SIZE (4096)
 #define WIFI_MARAUDER_TEXT_INPUT_STORE_SIZE (512)
+
+#define MARAUDER_APP_FOLDER ANY_PATH("marauder")
 
 struct WifiMarauderApp {
     Gui* gui;
@@ -29,7 +34,8 @@ struct WifiMarauderApp {
     size_t text_box_store_strlen;
     TextBox* text_box;
     TextInput* text_input;
-    //Widget* widget;
+    Storage* storage;
+    DialogsApp* dialogs;
 
     VariableItemList* var_item_list;
 

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -23,7 +23,6 @@
 #define WIFI_MARAUDER_TEXT_INPUT_STORE_SIZE (512)
 
 #define MARAUDER_APP_FOLDER ANY_PATH("apps_data/marauder")
-#define MARAUDER_CAPTURE_FILE_PREFIX MARAUDER_APP_FOLDER "/capture.pcap"
 
 struct WifiMarauderApp {
     Gui* gui;

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -6,6 +6,7 @@
 #include "scenes/wifi_marauder_scene.h"
 #include "wifi_marauder_custom_event.h"
 #include "wifi_marauder_uart.h"
+#include "wifi_marauder_pcap.h"
 
 #include <gui/gui.h>
 #include <gui/view_dispatcher.h>

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_app_i.h
@@ -22,7 +22,8 @@
 #define WIFI_MARAUDER_TEXT_BOX_STORE_SIZE (4096)
 #define WIFI_MARAUDER_TEXT_INPUT_STORE_SIZE (512)
 
-#define MARAUDER_APP_FOLDER ANY_PATH("marauder")
+#define MARAUDER_APP_FOLDER ANY_PATH("apps_data/marauder")
+#define MARAUDER_CAPTURE_FILE_PREFIX MARAUDER_APP_FOLDER "/capture.pcap"
 
 struct WifiMarauderApp {
     Gui* gui;
@@ -35,6 +36,7 @@ struct WifiMarauderApp {
     TextBox* text_box;
     TextInput* text_input;
     Storage* storage;
+    File* capture_file;
     DialogsApp* dialogs;
 
     VariableItemList* var_item_list;
@@ -47,6 +49,7 @@ struct WifiMarauderApp {
     bool is_custom_tx_string;
     bool focus_console_start;
     bool show_stopscan_tip;
+    bool is_writing;
 
     // For input source and destination MAC in targeted deauth attack
     int special_case_input_step;

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.c
@@ -15,7 +15,6 @@ void wifi_marauder_create_pcap_file(WifiMarauderApp* app) {
     char capture_file_path[100];
     wifi_marauder_get_prefix_from_cmd(prefix, app->selected_tx_string);
 
-    app->capture_file = storage_file_alloc(app->storage);
     int i=0;
     do{
         snprintf(capture_file_path, sizeof(capture_file_path), "%s/%s_%d.pcap", MARAUDER_APP_FOLDER, prefix, i);

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.c
@@ -1,0 +1,28 @@
+#include "wifi_marauder_app_i.h"
+#include "wifi_marauder_pcap.h"
+
+void wifi_marauder_get_prefix_from_cmd(char* dest, const char* command) {
+    int start, end, delta;
+    start = strlen("sniff");
+    end = strcspn(command, " ");
+    delta = end - start;
+    strncpy(dest, command + start, end - start);
+    dest[delta] = '\0';    
+}
+
+void wifi_marauder_create_pcap_file(WifiMarauderApp* app) {
+    char prefix[10];
+    char capture_file_path[100];
+    wifi_marauder_get_prefix_from_cmd(prefix, app->selected_tx_string);
+
+    app->capture_file = storage_file_alloc(app->storage);
+    int i=0;
+    do{
+        snprintf(capture_file_path, sizeof(capture_file_path), "%s/%s_%d.pcap", MARAUDER_APP_FOLDER, prefix, i);
+        i++;
+    } while(storage_file_exists(app->storage, capture_file_path));
+
+    if (!storage_file_open(app->capture_file, capture_file_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+        dialog_message_show_storage_error(app->dialogs, "Cannot open pcap file");
+    }
+}

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_pcap.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "furi_hal.h"
+
+/**
+ * Creates a PCAP file to store incoming packets.
+ * The file name will have a prefix according to the type of scan being performed by the application (Eg: raw_0.pcap)
+ * 
+ * @param app Application context
+ */
+void wifi_marauder_create_pcap_file(WifiMarauderApp* app);

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_uart.c
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_uart.c
@@ -2,10 +2,12 @@
 #include "wifi_marauder_uart.h"
 
 #define UART_CH (FuriHalUartIdUSART1)
+#define LP_UART_CH (FuriHalUartIdLPUART1)
 #define BAUDRATE (115200)
 
 struct WifiMarauderUart {
     WifiMarauderApp* app;
+    FuriHalUartId channel;
     FuriThread* rx_thread;
     FuriStreamBuffer* rx_stream;
     uint8_t rx_buf[RX_BUF_SIZE + 1];
@@ -60,23 +62,39 @@ void wifi_marauder_uart_tx(uint8_t* data, size_t len) {
     furi_hal_uart_tx(UART_CH, data, len);
 }
 
-WifiMarauderUart* wifi_marauder_uart_init(WifiMarauderApp* app) {
+void wifi_marauder_lp_uart_tx(uint8_t* data, size_t len) {
+    furi_hal_uart_tx(LP_UART_CH, data, len);
+}
+
+WifiMarauderUart* wifi_marauder_uart_init(WifiMarauderApp* app, FuriHalUartId channel, const char* thread_name) {
     WifiMarauderUart* uart = malloc(sizeof(WifiMarauderUart));
 
     uart->app = app;
+    uart->channel = channel;
     uart->rx_stream = furi_stream_buffer_alloc(RX_BUF_SIZE, 1);
     uart->rx_thread = furi_thread_alloc();
-    furi_thread_set_name(uart->rx_thread, "WifiMarauderUartRxThread");
+    furi_thread_set_name(uart->rx_thread, thread_name);
     furi_thread_set_stack_size(uart->rx_thread, 1024);
     furi_thread_set_context(uart->rx_thread, uart);
     furi_thread_set_callback(uart->rx_thread, uart_worker);
     furi_thread_start(uart->rx_thread);
-
-    furi_hal_console_disable();
-    furi_hal_uart_set_br(UART_CH, BAUDRATE);
-    furi_hal_uart_set_irq_cb(UART_CH, wifi_marauder_uart_on_irq_cb, uart);
+    if(channel == FuriHalUartIdUSART1) {
+        furi_hal_console_disable();
+    } else if(channel == FuriHalUartIdLPUART1) {
+        furi_hal_uart_init(channel, BAUDRATE);
+    }
+    furi_hal_uart_set_br(channel, BAUDRATE);
+    furi_hal_uart_set_irq_cb(channel, wifi_marauder_uart_on_irq_cb, uart);
 
     return uart;
+}
+
+WifiMarauderUart* wifi_marauder_usart_init(WifiMarauderApp* app) {
+    return wifi_marauder_uart_init(app, UART_CH,"WifiMarauderUartRxThread");
+}
+
+WifiMarauderUart* wifi_marauder_lp_uart_init(WifiMarauderApp* app) {
+    return wifi_marauder_uart_init(app, LP_UART_CH,"WifiMarauderLPUartRxThread");
 }
 
 void wifi_marauder_uart_free(WifiMarauderUart* uart) {
@@ -86,7 +104,7 @@ void wifi_marauder_uart_free(WifiMarauderUart* uart) {
     furi_thread_join(uart->rx_thread);
     furi_thread_free(uart->rx_thread);
 
-    furi_hal_uart_set_irq_cb(UART_CH, NULL, NULL);
+    furi_hal_uart_set_irq_cb(uart->channel, NULL, NULL);
     furi_hal_console_enable();
 
     free(uart);

--- a/applications/plugins/wifi_marauder_companion/wifi_marauder_uart.h
+++ b/applications/plugins/wifi_marauder_companion/wifi_marauder_uart.h
@@ -10,5 +10,7 @@ void wifi_marauder_uart_set_handle_rx_data_cb(
     WifiMarauderUart* uart,
     void (*handle_rx_data_cb)(uint8_t* buf, size_t len, void* context));
 void wifi_marauder_uart_tx(uint8_t* data, size_t len);
-WifiMarauderUart* wifi_marauder_uart_init(WifiMarauderApp* app);
+void wifi_marauder_lp_uart_tx(uint8_t* data, size_t len);
+WifiMarauderUart* wifi_marauder_usart_init(WifiMarauderApp* app);
+WifiMarauderUart* wifi_marauder_lp_uart_init(WifiMarauderApp* app);
 void wifi_marauder_uart_free(WifiMarauderUart* uart);


### PR DESCRIPTION
# What's new

- It is now possible to save Marauder pcaps without an SD card attached to the wifi devboard
- Now whenever a sniffing command is executed, the application will listen on the second serial channel (Low Power UART) for packets. If any data is received a file will be created in "apps_data/marauder/(function)_(index).pcap".

# Verification 

- To follow the implementation discussion:
https://forum.flipperzero.one/t/it-is-now-possible-to-save-marauder-pcaps-without-an-sd-card-attached-to-the-wifi-devboard/13255
- The Marauder firmware modified to send packets via serial is in this fork, while the merge request is not yet performed:
https://github.com/tcpassos/ESP32Marauder
- It is necessary to uncomment "#define WRITE_PACKETS_SERIAL" in configs.h and compile the firmware for the wifi board. Or simply use the binary in the releases tab.
- With the modified Marauder firmware it will be possible to test this PR by going to the "Sniff" menu and starting any sniffing function.
- A file "apps_data/marauder/(function)_(index).pcap" must be created if any package is received.

# Checklist (For Reviewer)

- [ ] Test whether the PCAP file is created after a scanning function
- [ ] Test that the generated PCAP file is not corrupted
