### PR TITLE
added an option to hop all channels on sniffpmkid and bug fix

### DIFF
--- a/script/menu/wifi_marauder_script_stage_menu_sniffpmkid.c
+++ b/script/menu/wifi_marauder_script_stage_menu_sniffpmkid.c
@@ -1,5 +1,26 @@
 #include "../../wifi_marauder_app_i.h"
 
+static void wifi_marauder_sniffpmkid_stage_hop_channels_setup_callback(VariableItem* item) {
+    WifiMarauderApp* app = variable_item_get_context(item);
+    WifiMarauderScriptStageSniffPmkid* stage = app->script_edit_selected_stage->stage;
+    variable_item_set_current_value_index(item, stage->hop_channels);
+}
+
+static void wifi_marauder_sniffpmkid_stage_hop_channels_change_callback(VariableItem* item) {
+    WifiMarauderApp* app = variable_item_get_context(item);
+
+    uint8_t current_stage_index = variable_item_list_get_selected_item_index(app->var_item_list);
+    const WifiMarauderScriptMenuItem* menu_item =
+            &app->script_stage_menu->items[current_stage_index];
+
+    uint8_t option_index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, menu_item->options[option_index]);
+
+    WifiMarauderScriptStageSniffPmkid* stage = app->script_edit_selected_stage->stage;
+    stage->hop_channels = option_index;
+}
+
+
 static void wifi_marauder_sniffpmkid_stage_force_deauth_setup_callback(VariableItem* item) {
     WifiMarauderApp* app = variable_item_get_context(item);
     WifiMarauderScriptStageSniffPmkid* stage = app->script_edit_selected_stage->stage;
@@ -65,8 +86,8 @@ static void wifi_marauder_sniffpmkid_stage_timeout_select_callback(void* context
 }
 
 void wifi_marauder_script_stage_menu_sniffpmkid_load(WifiMarauderScriptStageMenu* stage_menu) {
-    stage_menu->num_items = 3;
-    stage_menu->items = malloc(3 * sizeof(WifiMarauderScriptMenuItem));
+    stage_menu->num_items = 4;
+    stage_menu->items = malloc(4 * sizeof(WifiMarauderScriptMenuItem));
 
     stage_menu->items[0] = (WifiMarauderScriptMenuItem){
         .name = strdup("Force deauth"),
@@ -88,4 +109,11 @@ void wifi_marauder_script_stage_menu_sniffpmkid_load(WifiMarauderScriptStageMenu
         .num_options = 1,
         .setup_callback = wifi_marauder_sniffpmkid_stage_timeout_setup_callback,
         .select_callback = wifi_marauder_sniffpmkid_stage_timeout_select_callback};
+    stage_menu->items[3] = (WifiMarauderScriptMenuItem){
+            .name = strdup("Hop Channels"),
+            .type = WifiMarauderScriptMenuItemTypeOptionsString,
+            .num_options = 2,
+            .options = {"no", "yes"},
+            .setup_callback = wifi_marauder_sniffpmkid_stage_hop_channels_setup_callback,
+            .change_callback = wifi_marauder_sniffpmkid_stage_hop_channels_change_callback};
 }

--- a/script/wifi_marauder_script.c
+++ b/script/wifi_marauder_script.c
@@ -244,21 +244,34 @@ WifiMarauderScriptStageSniffPmkid* _wifi_marauder_script_get_stage_sniff_pmkid(c
 
     cJSON* channel_json = cJSON_GetObjectItem(sniffpmkid_stage_json, "channel");
     int channel = channel_json != NULL ? (int)cJSON_GetNumberValue(channel_json) : 0;
+
     cJSON* timeout_json = cJSON_GetObjectItem(sniffpmkid_stage_json, "timeout");
     int timeout = timeout_json != NULL ? (int)cJSON_GetNumberValue(timeout_json) :
-                                         WIFI_MARAUDER_DEFAULT_TIMEOUT_SNIFF;
+                  WIFI_MARAUDER_DEFAULT_TIMEOUT_SNIFF;
+
     cJSON* force_deauth_json =
-        cJSON_GetObjectItemCaseSensitive(sniffpmkid_stage_json, "forceDeauth");
+            cJSON_GetObjectItemCaseSensitive(sniffpmkid_stage_json, "forceDeauth");
     bool force_deauth = cJSON_IsBool(force_deauth_json) ? force_deauth_json->valueint : true;
 
+    cJSON* hop_channels_json =
+            cJSON_GetObjectItemCaseSensitive(sniffpmkid_stage_json, "hopChannels");
+    bool hop_channels = cJSON_IsBool(hop_channels_json) ? hop_channels_json->valueint : false;
+
     WifiMarauderScriptStageSniffPmkid* sniff_pmkid_stage =
-        (WifiMarauderScriptStageSniffPmkid*)malloc(sizeof(WifiMarauderScriptStageSniffPmkid));
+            (WifiMarauderScriptStageSniffPmkid*)malloc(sizeof(WifiMarauderScriptStageSniffPmkid));
+
+    if (sniff_pmkid_stage == NULL) {
+        // Handle memory allocation error
+        return NULL;
+    }
     sniff_pmkid_stage->channel = channel;
     sniff_pmkid_stage->timeout = timeout;
     sniff_pmkid_stage->force_deauth = force_deauth;
+    sniff_pmkid_stage->hop_channels = hop_channels;
 
     return sniff_pmkid_stage;
 }
+
 
 WifiMarauderScriptStageSniffPwn* _wifi_marauder_script_get_stage_sniff_pwn(cJSON* stages) {
     cJSON* sniffpwn_stage_json = cJSON_GetObjectItem(stages, "sniffpwn");
@@ -659,6 +672,9 @@ cJSON* _wifi_marauder_script_create_json_sniffpmkid(
     if(sniffpmkid_stage->timeout > 0) {
         cJSON_AddNumberToObject(sniffpmkid_json, "timeout", sniffpmkid_stage->timeout);
     }
+    // Hop channels
+    cJSON_AddBoolToObject(sniffpmkid_json, "hopChannels", sniffpmkid_stage->hop_channels);
+
     return stage_json;
 }
 

--- a/script/wifi_marauder_script.h
+++ b/script/wifi_marauder_script.h
@@ -196,6 +196,7 @@ typedef struct WifiMarauderScriptStageSniffEsp {
 
 typedef struct WifiMarauderScriptStageSniffPmkid {
     bool force_deauth;
+    bool hop_channels;
     int channel;
     int timeout;
 } WifiMarauderScriptStageSniffPmkid;

--- a/script/wifi_marauder_script_worker.c
+++ b/script/wifi_marauder_script_worker.c
@@ -1,6 +1,7 @@
 #include "../wifi_marauder_app_i.h"
 #include "wifi_marauder_script_worker.h"
 
+
 WifiMarauderScriptWorker* wifi_marauder_script_worker_alloc() {
     WifiMarauderScriptWorker* worker = malloc(sizeof(WifiMarauderScriptWorker));
     if(worker == NULL) {
@@ -39,6 +40,7 @@ int32_t _wifi_marauder_script_worker_task(void* worker) {
     }
 
     script_worker->is_running = false;
+
     return WifiMarauderScriptWorkerStatusSuccess;
 }
 


### PR DESCRIPTION
i've added a feature on `sniffpmkid`, to hop all 11 channels, so timeout is per channel. this allows capturing all channels without being tied to a `scanap` output. i also fixed a bug on custom command, where the newline wasn't being sent. 