### PR TITLE
Add SAE commands and remove BT cont

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -1,7 +1,7 @@
 App(
     appid="esp32_wifi_marauder",
     name="[ESP32] WiFi Marauder",
-    fap_version=(7, 7),
+    fap_version=(7, 8),
     apptype=FlipperAppType.EXTERNAL,
     entry_point="wifi_marauder_app",
     requires=["gui"],

--- a/scenes/wifi_marauder_scene_start.c
+++ b/scenes/wifi_marauder_scene_start.c
@@ -12,7 +12,7 @@ typedef enum { FOCUS_CONSOLE_END = 0, FOCUS_CONSOLE_START, FOCUS_CONSOLE_TOGGLE 
 #define SHOW_STOPSCAN_TIP (true)
 #define NO_TIP (false)
 
-#define MAX_OPTIONS (15)
+#define MAX_OPTIONS (16)
 typedef struct {
     const char* item_string;
     const char* options_menu[MAX_OPTIONS];
@@ -89,19 +89,21 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
       "funny",
       "badmsg",
       "sleep",
+      "sae flood",
       "sour apple",
       "swiftpair spam",
       "samsung spam",
       "google spam",
       "flipper spam",
       "bt spam all"},
-     12,
+     13,
      {"attack -t deauth",
       "attack -t probe",
       "attack -t rickroll",
       "attack -t funny",
       "attack -t badmsg",
       "attack -t sleep",
+      "attack -t sae",
       "blespam -t apple",
       "blespam -t windows",
       "blespam -t samsung",
@@ -119,9 +121,9 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      NO_TIP},
     {"Wardrive",
-     {"ap", "station", "flock", "bt", "bt cont"},
-     5,
-     {"wardrive", "wardrive -s", "wardrive -f", "btwardrive", "btwardrive -c"},
+     {"ap", "station", "flock", "bt"},
+     4,
+     {"wardrive", "wardrive -s", "wardrive -f", "btwardrive"},
      NO_ARGS,
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
@@ -176,8 +178,8 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
     {"Sniff",
-     {"beacon", "deauth", "pmkid", "probe", "pwn", "raw", "bt", "skim", "airtag", "flipper", "flock", "mactrack", "packetcount", "pineapple", "multissid"},
-     15,
+     {"beacon", "deauth", "pmkid", "probe", "pwn", "raw", "bt", "skim", "airtag", "flipper", "flock", "mactrack", "packetcount", "pineapple", "multissid", "sae"},
+     16,
      {"sniffbeacon",
       "sniffdeauth",
       "sniffpmkid",
@@ -192,7 +194,8 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
       "mactrack",
       "packetcount",
       "sniffpinescan",
-      "sniffmultissid"},
+      "sniffmultissid",
+      "sniffsae"},
      NO_ARGS,
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},

--- a/wifi_marauder_app.h
+++ b/wifi_marauder_app.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define WIFI_MARAUDER_APP_VERSION "v0.7.7"
+#define WIFI_MARAUDER_APP_VERSION "v0.7.8"
 
 typedef struct WifiMarauderApp WifiMarauderApp;
 


### PR DESCRIPTION
- Continuous bluetooth wardrive is removed in Marauder v1.10.0
- Add command for `sniffsae`
- Add command for `attack -t sae`
- Adjust max options for additional sniff command