### PR TITLE
Sync Marauder commands with current upstream firmware

### DIFF
--- a/scenes/wifi_marauder_scene_start.c
+++ b/scenes/wifi_marauder_scene_start.c
@@ -12,7 +12,7 @@ typedef enum { FOCUS_CONSOLE_END = 0, FOCUS_CONSOLE_START, FOCUS_CONSOLE_TOGGLE 
 #define SHOW_STOPSCAN_TIP (true)
 #define NO_TIP (false)
 
-#define MAX_OPTIONS (16)
+#define MAX_OPTIONS (17)
 typedef struct {
     const char* item_string;
     const char* options_menu[MAX_OPTIONS];
@@ -27,9 +27,9 @@ typedef struct {
 const WifiMarauderItem items[NUM_MENU_ITEMS] = {
     {"View Log from", {"start", "end"}, 2, {"", ""}, NO_ARGS, FOCUS_CONSOLE_TOGGLE, NO_TIP},
     {"Scan",
-     {"all", "ap", "station", "ping", "arp"},
-     5,
-     {"scanall", "scanap", "scansta", "pingscan", "arpscan"},
+     {"all", "ping", "arp"},
+     3,
+     {"scanall", "pingscan", "arpscan"},
      NO_ARGS,
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
@@ -90,13 +90,16 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
       "badmsg",
       "sleep",
       "sae flood",
+      "csa",
+      "quiet",
       "sour apple",
+      "apple juice",
       "swiftpair spam",
       "samsung spam",
       "google spam",
       "flipper spam",
       "bt spam all"},
-     13,
+     16,
      {"attack -t deauth",
       "attack -t probe",
       "attack -t rickroll",
@@ -104,7 +107,10 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
       "attack -t badmsg",
       "attack -t sleep",
       "attack -t sae",
-      "blespam -t apple",
+      "attack -t csa",
+      "attack -t quiet",
+      "blespam -t sourapple",
+      "blespam -t applejuice",
       "blespam -t windows",
       "blespam -t samsung",
       "blespam -t google",
@@ -121,9 +127,9 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      NO_TIP},
     {"Wardrive",
-     {"ap", "station", "flock", "bt"},
-     4,
-     {"wardrive", "wardrive -s", "wardrive -f", "btwardrive"},
+     {"ap", "station", "flock"},
+     3,
+     {"wardrive", "wardrive -s", "wardrive -f"},
      NO_ARGS,
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
@@ -178,8 +184,8 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
     {"Sniff",
-     {"beacon", "deauth", "pmkid", "probe", "pwn", "raw", "bt", "skim", "airtag", "flipper", "flock", "mactrack", "packetcount", "pineapple", "multissid", "sae"},
-     16,
+     {"beacon", "deauth", "pmkid", "probe", "pwn", "raw", "bt", "skim", "airtag", "flipper", "flock", "meta", "mactrack", "packetcount", "pineapple", "multissid", "sae"},
+     17,
      {"sniffbeacon",
       "sniffdeauth",
       "sniffpmkid",
@@ -191,6 +197,7 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
       "sniffbt -t airtag",
       "sniffbt -t flipper",
       "sniffbt -t flock",
+      "sniffbt -t meta",
       "mactrack",
       "packetcount",
       "sniffpinescan",


### PR DESCRIPTION
## Summary

Realigns the menu in `scenes/wifi_marauder_scene_start.c` with the current `ESP32Marauder` firmware (`CommandLine.h`).

### Removed (firmware no longer accepts these)
- **Scan > ap** (`scanap`) — removed in Marauder v1.12.0; `scanall` now covers AP scanning. Fixes #79.
- **Scan > station** (`scansta`) — `SCANSTA_CMD` is commented out upstream.
- **Wardrive > bt** (`btwardrive`) — `BT_WARDRIVE_CMD` is commented out upstream.

### Renamed
- **Attack > sour apple** — `blespam -t apple` → `blespam -t sourapple` (firmware now matches `sourapple`/`applejuice`, not `apple`).

### Added
- **Attack > apple juice** — `blespam -t applejuice`
- **Attack > csa** — `attack -t csa` (Channel Switch Announcement)
- **Attack > quiet** — `attack -t quiet`
- **Sniff > meta** — `sniffbt -t meta` (Meta/Rayban devices)

### Misc
- Bump `MAX_OPTIONS` from 16 to 17 so the Sniff submenu can hold its 17th entry.

## Test plan
- [ ] Build the .fap with `ufbt` and side-load on Flipper Zero
- [ ] Verify Scan submenu shows `all / ping / arp` only
- [ ] Verify Wardrive submenu shows `ap / station / flock` only
- [ ] Verify Attack submenu includes new entries `apple juice`, `csa`, `quiet`
- [ ] Verify Sniff submenu includes new `meta` entry between `flock` and `mactrack`
- [ ] Run `attack -t csa`, `attack -t quiet`, `blespam -t sourapple`, `blespam -t applejuice`, `sniffbt -t meta` against an ESP32 running current Marauder firmware