### PR TITLE
Show stopscan tip for NMEA Stream

### DIFF
--- a/scenes/wifi_marauder_scene_start.c
+++ b/scenes/wifi_marauder_scene_start.c
@@ -249,7 +249,7 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
      NO_ARGS,
      FOCUS_CONSOLE_END,
      NO_TIP},
-    {"NMEA Stream", {""}, 1, {"nmea"}, NO_ARGS, FOCUS_CONSOLE_END, NO_TIP},
+    {"NMEA Stream", {""}, 1, {"nmea"}, NO_ARGS, FOCUS_CONSOLE_END, SHOW_STOPSCAN_TIP},
     {"GPS POI",
      {"start", "mark", "end"},
      3,


### PR DESCRIPTION
`nmea` starts a scan mode and streams until you send `stopscan`, but the row is marked `NO_TIP`, so you never get the "Press BACK to send stopscan" hint.

Every other row that starts a scan has it, i think it was just missed in #84.
