### PR TITLE
Add SPIFFS backup and restore

### DIFF
--- a/scenes/wifi_marauder_scene_start.c
+++ b/scenes/wifi_marauder_scene_start.c
@@ -273,6 +273,13 @@ const WifiMarauderItem items[NUM_MENU_ITEMS] = {
     {"Reboot", {""}, 1, {"reboot"}, NO_ARGS, FOCUS_CONSOLE_END, NO_TIP},
     {"Help", {""}, 1, {"help"}, NO_ARGS, FOCUS_CONSOLE_START, SHOW_STOPSCAN_TIP},
     {"Info", {""}, 1, {"info"}, NO_ARGS, FOCUS_CONSOLE_START, NO_TIP},
+    {"SPIFFS",
+     {"backup", "status", "restore"},
+     3,
+     {"backupspiffs", "backupstatus", "restorespiffs"},
+     NO_ARGS,
+     FOCUS_CONSOLE_END,
+     SHOW_STOPSCAN_TIP},
     {"Scripts", {""}, 1, {""}, NO_ARGS, FOCUS_CONSOLE_END, NO_TIP},
     {"Save to flipper sdcard", // keep as last entry or change logic in callback below
      {""},

--- a/wifi_marauder_app_i.h
+++ b/wifi_marauder_app_i.h
@@ -27,7 +27,7 @@
 #include <lib/toolbox/path.h>
 #include <dialogs/dialogs.h>
 
-#define NUM_MENU_ITEMS (34)
+#define NUM_MENU_ITEMS (35)
 
 #define WIFI_MARAUDER_TEXT_BOX_STORE_SIZE (4096)
 #define WIFI_MARAUDER_TEXT_INPUT_STORE_SIZE (512)


### PR DESCRIPTION
Adds a SPIFFS menu with backup, status and restore, mapped to the `backupspiffs`, `backupstatus` and `restorespiffs` commands from https://github.com/justcallmekoko/ESP32Marauder/wiki/SPIFFS-Backup-and-Restore.

I left out the `--machine` protocol variants, those are for installer tools and would need a transaction id.